### PR TITLE
V1.0.0-remove-app-group-namespace-bing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,34 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for more information:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-# https://containers.dev/guide/dependabot
-
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  # Update Cargo dependencies
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # Update GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  # Update Dev Container dependencies
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,40 +2,58 @@ name: CI
 
 on:
   push:
-    tags: ["v*"]
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
 
 jobs:
-  # test:
-  #   runs-on: ubuntu-latest
-  #   services:
-  #     rabbitmq:
-  #       image: rabbitmq:3-management
-  #       ports:
-  #         - 5672:5672
-  #         - 15672:15672
-  #       options: >-
-  #         --health-cmd "rabbitmq-diagnostics -q ping"
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         override: true
-  #     - run: cargo test
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
 
-  publish:
-    name: Publish to Crates.io
-    # needs: test
-    if: startsWith(github.ref, 'refs/tags/v')
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests with Docker (testcontainers)
+        run: cargo test --verbose
+        env:
+          RUST_LOG: debug
+
+  security-audit:
+    name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --color always
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+      - name: Run security audit
+        run: cargo audit

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,95 @@
+name: Maintenance
+
+on:
+  schedule:
+    # Run every Monday at 9 AM UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  dependency-check:
+    name: Dependency Check
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-outdated
+        run: cargo install cargo-outdated
+
+      - name: Check for outdated dependencies
+        run: |
+          echo "## Dependency Status Report" >> dependency-report.md
+          echo "" >> dependency-report.md
+          echo "Generated on: $(date)" >> dependency-report.md
+          echo "" >> dependency-report.md
+          
+          echo "### Outdated Dependencies" >> dependency-report.md
+          cargo outdated --format json > outdated.json || true
+          
+          if [ -s outdated.json ] && [ "$(cat outdated.json)" != "[]" ]; then
+            echo "Found outdated dependencies" >> dependency-report.md
+            cargo outdated >> dependency-report.md
+          else
+            echo "✅ All dependencies are up to date!" >> dependency-report.md
+          fi
+
+      - name: Security audit
+        run: |
+          cargo install cargo-audit
+          echo "" >> dependency-report.md
+          echo "### Security Audit" >> dependency-report.md
+          
+          if cargo audit --format json > audit.json; then
+            echo "✅ No security vulnerabilities found!" >> dependency-report.md
+          else
+            echo "⚠️ Security vulnerabilities detected:" >> dependency-report.md
+            cargo audit >> dependency-report.md
+          fi
+
+      - name: Upload dependency report
+        uses: actions/upload-artifact@v3
+        with:
+          name: dependency-report
+          path: dependency-report.md
+
+  test-matrix:
+    name: Test on Multiple Rust Versions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust-version: [stable, beta, nightly]
+        continue-on-error: ${{ matrix.rust-version == 'nightly' }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust-version }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.rust-version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose
+        continue-on-error: ${{ matrix.rust-version == 'nightly' }}
+
+      - name: Report status
+        run: |
+          echo "✅ Tests passed on Rust ${{ matrix.rust-version }}"

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,180 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.0.0)'
+        required: true
+        type: string
+      create_tag:
+        description: 'Create git tag'
+        required: true
+        type: boolean
+        default: true
+      publish_crates:
+        description: 'Publish to crates.io'
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  validate-version:
+    name: Validate Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+      
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate version format
+        id: validate
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          
+          # Check if version follows semantic versioning
+          if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "❌ Invalid version format: $VERSION"
+            echo "Version must follow semantic versioning (e.g., 1.0.0, 1.0.0-beta.1)"
+            exit 1
+          fi
+          
+          echo "✅ Version format is valid: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+  update-version:
+    name: Update Version in Cargo.toml
+    runs-on: ubuntu-latest
+    needs: validate-version
+    outputs:
+      updated: ${{ steps.update.outputs.updated }}
+      
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Cargo.toml version
+        id: update
+        run: |
+          VERSION="${{ needs.validate-version.outputs.version }}"
+          CURRENT_VERSION=$(grep '^version = ' Cargo.toml | head -n1 | sed 's/version = "\(.*\)"/\1/')
+          
+          echo "Current version: $CURRENT_VERSION"
+          echo "Target version: $VERSION"
+          
+          if [ "$CURRENT_VERSION" = "$VERSION" ]; then
+            echo "Version is already $VERSION, no update needed"
+            echo "updated=false" >> $GITHUB_OUTPUT
+          else
+            # Update version in Cargo.toml
+            sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+            
+            # Configure git
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            
+            # Commit the version update
+            git add Cargo.toml
+            git commit -m "chore: bump version to $VERSION"
+            git push
+            
+            echo "✅ Updated version to $VERSION"
+            echo "updated=true" >> $GITHUB_OUTPUT
+          fi
+
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    needs: [validate-version, update-version]
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run all tests
+        run: cargo test --verbose
+        env:
+          RUST_LOG: info
+
+  create-tag:
+    name: Create Git Tag
+    runs-on: ubuntu-latest
+    needs: [validate-version, update-version, test]
+    if: github.event.inputs.create_tag == 'true'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create and push tag
+        run: |
+          VERSION="${{ needs.validate-version.outputs.version }}"
+          TAG_NAME="v$VERSION"
+          
+          # Configure git
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          
+          # Create annotated tag
+          git tag -a "$TAG_NAME" -m "Release version $VERSION
+
+          Released via manual workflow dispatch.
+          
+          This release includes:
+          - All tests passing ✅
+          - Updated documentation
+          - Version bump to $VERSION"
+          
+          git push origin "$TAG_NAME"
+          
+          echo "✅ Created and pushed tag: $TAG_NAME"
+
+  publish-crates:
+    name: Publish to Crates.io
+    runs-on: ubuntu-latest
+    needs: [validate-version, update-version, test]
+    if: github.event.inputs.publish_crates == 'true'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Publish to crates.io
+        run: |
+          echo "🚀 Publishing version ${{ needs.validate-version.outputs.version }} to crates.io..."
+          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --color always
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Notify success
+        run: |
+          echo "✅ Successfully published version ${{ needs.validate-version.outputs.version }} to crates.io!"
+          echo "📦 Package is now available at: https://crates.io/crates/rabbitmq_streamer"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,0 +1,144 @@
+name: Pull Request Tests
+
+on:
+  pull_request:
+    branches: [ "main", "develop" ]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# Cancel previous runs for the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run unit tests
+        run: cargo test --lib --verbose
+
+      - name: Run publisher integration tests
+        run: cargo test --test publisher_tests --verbose
+        env:
+          RUST_LOG: info
+
+      - name: Run consumer integration tests
+        run: cargo test --test consumer_tests --verbose
+        env:
+          RUST_LOG: info
+
+      - name: Run integration tests
+        run: cargo test --test integration_tests --verbose
+        env:
+          RUST_LOG: info
+
+      - name: Generate test report
+        if: always()
+        run: |
+          echo "## Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ All tests completed for PR #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Test Coverage" >> $GITHUB_STEP_SUMMARY
+          echo "- Publisher tests: ✅" >> $GITHUB_STEP_SUMMARY
+          echo "- Consumer tests: ✅" >> $GITHUB_STEP_SUMMARY
+          echo "- Integration tests: ✅" >> $GITHUB_STEP_SUMMARY
+          echo "- Code formatting: ✅" >> $GITHUB_STEP_SUMMARY
+          echo "- Clippy lints: ✅" >> $GITHUB_STEP_SUMMARY
+
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Run security audit
+        run: cargo audit
+
+  check-docs:
+    name: Check Documentation
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Check documentation
+        run: cargo doc --no-deps --document-private-items
+
+      - name: Check for documentation warnings
+        run: |
+          RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
+
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Generate code coverage
+        run: |
+          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./cobertura.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,178 @@
+name: Release and Publish
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'Cargo.toml'
+      - 'src/**'
+      - 'README.md'
+      - 'TESTING.md'
+
+jobs:
+  check-version:
+    name: Check if version changed
+    runs-on: ubuntu-latest
+    outputs:
+      version-changed: ${{ steps.check-version.outputs.changed }}
+      new-version: ${{ steps.check-version.outputs.version }}
+      
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if version changed
+        id: check-version
+        run: |
+          # Get current version from Cargo.toml
+          CURRENT_VERSION=$(grep '^version = ' Cargo.toml | head -n1 | sed 's/version = "\(.*\)"/\1/')
+          
+          # Get previous version from the commit before
+          git checkout HEAD~1 -- Cargo.toml || echo "No previous Cargo.toml found"
+          PREVIOUS_VERSION=$(grep '^version = ' Cargo.toml | head -n1 | sed 's/version = "\(.*\)"/\1/' || echo "0.0.0")
+          
+          # Restore current Cargo.toml
+          git checkout HEAD -- Cargo.toml
+          
+          echo "Previous version: $PREVIOUS_VERSION"
+          echo "Current version: $CURRENT_VERSION"
+          
+          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+            echo "Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "Version has not changed"
+          fi
+
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    needs: check-version
+    if: needs.check-version.outputs.version-changed == 'true'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run all tests
+        run: cargo test --verbose
+        env:
+          RUST_LOG: info
+
+  create-tag:
+    name: Create Git Tag
+    runs-on: ubuntu-latest
+    needs: [check-version, test]
+    if: needs.check-version.outputs.version-changed == 'true'
+    outputs:
+      tag-name: ${{ steps.create-tag.outputs.tag-name }}
+      
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create and push tag
+        id: create-tag
+        run: |
+          VERSION="${{ needs.check-version.outputs.new-version }}"
+          TAG_NAME="v$VERSION"
+          
+          # Configure git
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          
+          # Create annotated tag
+          git tag -a "$TAG_NAME" -m "Release version $VERSION"
+          git push origin "$TAG_NAME"
+          
+          echo "tag-name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "Created and pushed tag: $TAG_NAME"
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [check-version, test, create-tag]
+    if: needs.check-version.outputs.version-changed == 'true'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          VERSION="${{ needs.check-version.outputs.new-version }}"
+          
+          # Create a basic changelog from recent commits
+          echo "## Changes in v$VERSION" > CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          git log --oneline --since="1 week ago" --pretty=format:"- %s" >> CHANGELOG.md
+          
+          # Set output for release body
+          echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
+          cat CHANGELOG.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.create-tag.outputs.tag-name }}
+          release_name: Release ${{ needs.create-tag.outputs.tag-name }}
+          body: ${{ steps.changelog.outputs.CHANGELOG }}
+          draft: false
+          prerelease: false
+
+  publish-crates:
+    name: Publish to Crates.io
+    runs-on: ubuntu-latest
+    needs: [check-version, test, create-tag]
+    if: needs.check-version.outputs.version-changed == 'true'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Publish to crates.io
+        run: |
+          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --color always
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Notify success
+        run: |
+          echo "✅ Successfully published version ${{ needs.check-version.outputs.new-version }} to crates.io!"
+          echo "🏷️  Created tag: ${{ needs.create-tag.outputs.tag-name }}"

--- a/CI_CD.md
+++ b/CI_CD.md
@@ -1,0 +1,148 @@
+# CI/CD Pipeline
+
+This repository uses GitHub Actions for continuous integration and deployment. The pipeline is designed to automatically test code, create releases, and publish to crates.io.
+
+## Workflows Overview
+
+### 1. `ci.yml` - Continuous Integration
+**Triggers:** Push to `main` or `develop`, Pull Requests
+- ✅ Code formatting check (`cargo fmt`)
+- ✅ Linting with Clippy
+- ✅ Build verification
+- ✅ Run all tests (including testcontainers)
+- ✅ Security audit
+
+### 2. `pr-test.yml` - Pull Request Testing
+**Triggers:** Pull Request events (opened, synchronized, etc.)
+- 🧪 Comprehensive test suite
+- 📊 Code coverage analysis
+- 📖 Documentation checks
+- 🔒 Security auditing
+- 📋 Test result summaries
+
+### 3. `release.yml` - Automated Release Pipeline
+**Triggers:** Push to `main` branch (when version changes)
+
+**Process:**
+1. **Version Detection** - Automatically detects version changes in `Cargo.toml`
+2. **Testing** - Runs full test suite
+3. **Git Tagging** - Creates annotated git tags (e.g., `v1.0.0`)
+4. **GitHub Release** - Creates release with changelog
+5. **Crates.io Publishing** - Automatically publishes to crates.io
+
+### 4. `manual-release.yml` - Manual Release Workflow
+**Triggers:** Manual workflow dispatch
+
+Allows maintainers to:
+- Specify version number
+- Choose whether to create git tags
+- Choose whether to publish to crates.io
+- Update `Cargo.toml` version automatically
+
+### 5. `maintenance.yml` - Weekly Maintenance
+**Triggers:** Weekly schedule (Mondays) + Manual trigger
+- 🔍 Dependency outdated check
+- 🛡️ Security vulnerability scanning
+- 🧪 Multi-version Rust testing (stable, beta, nightly)
+
+## Required Secrets
+
+The following secrets must be configured in the repository:
+
+### `CARGO_REGISTRY_TOKEN`
+- **Purpose:** Publishing to crates.io
+- **How to get:** 
+  1. Go to [crates.io](https://crates.io)
+  2. Login and go to Account Settings
+  3. Generate a new API token
+  4. Add to GitHub repository secrets
+
+### `GITHUB_TOKEN`
+- **Purpose:** Creating releases and pushing tags
+- **Note:** Automatically provided by GitHub Actions
+
+## Automatic Release Process
+
+When you want to release a new version:
+
+### Method 1: Automatic (Recommended)
+1. Update the version in `Cargo.toml`
+2. Commit and push to `main` branch
+3. The pipeline automatically:
+   - Detects version change
+   - Runs tests
+   - Creates git tag
+   - Creates GitHub release
+   - Publishes to crates.io
+
+### Method 2: Manual Release
+1. Go to GitHub Actions tab
+2. Select "Manual Release" workflow
+3. Click "Run workflow"
+4. Enter version number and options
+5. The pipeline handles the rest
+
+## Testing Strategy
+
+The pipeline uses **testcontainers** to run integration tests with real RabbitMQ instances:
+
+- **Publisher Tests** - Test message publishing functionality
+- **Consumer Tests** - Test message consumption with auto/manual ack
+- **Integration Tests** - End-to-end publisher-consumer scenarios
+
+### Test Environment
+- Uses Docker containers for RabbitMQ
+- Isolated test environments
+- Comprehensive error handling testing
+- Multiple routing key scenarios
+
+## Branch Protection
+
+Recommended branch protection rules for `main`:
+
+- ✅ Require status checks to pass
+- ✅ Require branches to be up to date
+- ✅ Require pull request reviews
+- ✅ Dismiss stale reviews
+- ✅ Restrict pushes to main
+
+## Monitoring and Notifications
+
+The pipeline provides:
+- 📊 Test result summaries in PR comments
+- 🏷️ Automatic version tagging
+- 📦 Release notifications
+- ⚠️ Security vulnerability alerts
+- 📈 Code coverage reports
+
+## Troubleshooting
+
+### Common Issues
+
+**Tests fail with Docker errors:**
+- Ensure GitHub Actions has Docker available
+- Check testcontainers configuration
+
+**Publishing fails:**
+- Verify `CARGO_REGISTRY_TOKEN` is valid
+- Check if version already exists on crates.io
+
+**Version detection issues:**
+- Ensure `Cargo.toml` version follows semantic versioning
+- Check that version actually changed from previous commit
+
+### Manual Intervention
+
+If automatic processes fail:
+1. Check GitHub Actions logs
+2. Use manual release workflow as fallback
+3. Verify all secrets are properly configured
+4. Ensure branch protection rules allow the action
+
+## Performance Optimizations
+
+The workflows include several optimizations:
+- **Cargo caching** - Speeds up builds
+- **Parallel job execution** - Faster overall pipeline
+- **Conditional execution** - Only runs when needed
+- **Incremental testing** - Focused test execution

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,8 +1570,10 @@ dependencies = [
  "serde",
  "serde_json",
  "testcontainers",
+ "testcontainers-modules",
  "tokio",
  "tokio-stream",
+ "tokio-test",
  "tracing",
  "uuid",
 ]
@@ -2012,6 +2036,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "testcontainers-modules"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+dependencies = [
+ "testcontainers",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2166,19 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "xattr",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ log = "0.4.27"
 
 [dev-dependencies]
 testcontainers = "0.23"
+testcontainers-modules = { version = "0.11", features = ["rabbitmq"] }
+tokio-test = "0.4"
+serde = { version = "1", features = ["derive"] }
 
 
 [features]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ cargo test --test integration_tests
 
 For detailed testing information, see [TESTING.md](TESTING.md).
 
+### CI/CD Pipeline
+
+This project uses GitHub Actions for automated testing and publishing:
+- **Continuous Integration** - Automatic testing on every push and PR
+- **Automated Releases** - Publishes to crates.io when version changes on main branch
+- **Security Audits** - Weekly dependency and security checks
+
+For complete CI/CD documentation, see [CI_CD.md](CI_CD.md).
+
 ### Examples
 
 #### Publishing Messages

--- a/README.md
+++ b/README.md
@@ -1,48 +1,320 @@
 ## RabbitMQ Streammer
 
-A library for streaming messages from RabbitMQ. It provides a high-level API for connecting to RabbitMQ and consuming messages from queues.
+[crates-badge]: https://img.shields.io/crates/v/rabbitmq_streammer.svg
+[crates-url]: https://crates.io/crates/rabbitmq_streammer
+[mit-url]: https://github.com/cgbur/rabbitmq_streammer/blob/master/LICENSE
+[mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
+
+[![Crates.io][crates-badge]][[crates-url](https://crates.io/crates/rabbitmq_streamer)]
+
+A easy library for publishing to RabbitMQ and Consuming from it using [Rust Streams](https://doc.rust-lang.org/book/ch17-04-streams.html). It provides a high-level API for connecting to RabbitMQ, publishing, consuming messages from queues and acking them in batches.
+
 
 ### Features
 
-- **RabbitConsumer**: A struct representing a RabbitMQ consumer that connects to a RabbitMQ broker, binds the specified queue to an exchange, and loads messages from the specified queue.
-  - **Parameters**:
-    - `channel`: A reference-counted handle to a channel used to receive messages.
-    - `queue_name`: The name of the queue where messages will be consumed.
-    - `app_group_namespace`: An identifier for the application used to create routing keys, which helps in segregating messages based on different applications or groups.
+- **RabbitPublisher**: A high-level publisher for sending messages to RabbitMQ exchanges
+  - Connect to RabbitMQ brokers with automatic exchange binding
+  - Publish serializable messages with custom routing keys
+  - Built-in JSON serialization for message payloads
+  - Durable exchange declarations with configurable options
 
-- **RabbitPublisher**: A struct representing a RabbitMQ publisher that connects to a RabbitMQ broker, binds the specified exchange, and publishes messages to it.
-  - **Parameters**:
-    - `channel`: A reference-counted handle to a channel used to send messages.
-    - `exchange_name`: The name of the exchange where messages will be published.
-    - `app_group_namespace`: An identifier for the application used to create routing keys, which helps in segregating messages based on different applications or groups.
+- **RabbitConsumer**: A stream-based consumer for receiving messages from RabbitMQ queues
+  - **Auto-acknowledged messages**: Use `load_messages()` to consume messages that are automatically acknowledged upon receipt
+  - **Manual acknowledgment**: Use `load_ackable_messages()` to receive `AckableMessage<T>` instances for manual message acknowledgment control
+  - Automatic reconnection and error handling with configurable retry intervals
+  - Built-in JSON deserialization for message payloads
+  - Support for custom consumer tags and channel buffer sizing
+
+- **AckableMessage**: Wrapper for messages requiring manual acknowledgment
+  - `ack()`: Acknowledge successful message processing
+  - `nack()`: Negative acknowledge with requeue option
+  - `reject()`: Reject message without requeue
+  - Access to the original message payload through `message()`
+
+
+
+### Testing
+
+This library includes comprehensive tests using testcontainers to ensure reliability with real RabbitMQ instances. The test suite covers:
+
+- **Publisher tests**: Connection, message publishing, multiple messages, and different routing keys
+- **Consumer tests**: Connection, auto-acknowledged messages, manual acknowledgment, and custom consumer tags
+- **Integration tests**: End-to-end scenarios with both publisher and consumer working together
+
+To run the tests:
+
+```bash
+# Run all tests (requires Docker)
+cargo test
+
+# Run specific test suites
+cargo test --test publisher_tests
+cargo test --test consumer_tests
+cargo test --test integration_tests
+```
+
+For detailed testing information, see [TESTING.md](TESTING.md).
 
 ### Examples
 
-#### Setting Up a RabbitConsumer
+#### Publishing Messages
 
 ```rust
-use rabbitmq_streammer::RabbitConsumer;
-use futures::StreamExt;
-use serde::Deserialize;
+use rabbitmq_streamer::RabbitPublisher;
+use serde::Serialize;
 
-#[derive(Deserialize)]
-struct Payload {
-    data: String,
-    id: u32,
+#[derive(Serialize)]
+struct OrderEvent {
+    order_id: u32,
+    customer_id: u32,
+    amount: f64,
+    status: String,
 }
 
 #[tokio::main]
-async fn main() {
-    let uri = "amqp://admin:password@pipe:5672";
-    let queue_name = "paylods";
-    let app_group_namespace = "test_application";
-    let exchange_name = "test";
+async fn main() -> anyhow::Result<()> {
+    let uri = "amqp://guest:guest@localhost:5672";
+    let exchange_name = "orders";
+    let app_namespace = "order_service";
 
-    let consumer = RabbitConsumer::connect(uri, queue_name, app_group_namespace, exchange_name).await.unwrap();
+    // Connect to RabbitMQ and create publisher
+    let publisher = RabbitPublisher::connect(uri, exchange_name, app_namespace).await?;
 
-    let mut messages = consumer.load_messages::<Vec<Payload>>(10, "test-tag").await.unwrap();
+    // Create and publish a message
+    let order = OrderEvent {
+        order_id: 12345,
+        customer_id: 67890,
+        amount: 99.99,
+        status: "created".to_string(),
+    };
 
-    while let Some(message) = messages.next().await {
-        println!("Received message: {:?}", message);
+    // Publish with routing key
+    publisher.publish(&order, "orders.created").await?;
+
+    println!("Order event published successfully!");
+    Ok(())
+}
+```
+
+#### Consuming Messages with Auto-Acknowledgment
+
+```rust
+use rabbitmq_streamer::RabbitConsumer;
+use serde::Deserialize;
+use tokio::time::{timeout, Duration};
+
+#[derive(Deserialize, Debug)]
+struct OrderEvent {
+    order_id: u32,
+    customer_id: u32,
+    amount: f64,
+    status: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let uri = "amqp://guest:guest@localhost:5672";
+    let queue_name = "order_events";
+
+    // Connect to RabbitMQ and create consumer
+    let consumer = RabbitConsumer::connect(uri, queue_name).await?;
+
+    // Start consuming messages (auto-acknowledged)
+    let mut message_receiver = consumer
+        .load_messages::<OrderEvent, _>(10, Some("order-processor"))
+        .await?;
+
+    println!("Waiting for messages...");
+
+    // Process messages
+    while let Ok(Some(order)) = timeout(Duration::from_secs(30), message_receiver.recv()).await {
+        println!("Received order: {:?}", order);
+        
+        // Process the order here
+        // Message is automatically acknowledged
+    }
+
+    Ok(())
+}
+```
+
+#### Consuming Messages with Manual Acknowledgment
+
+```rust
+use rabbitmq_streamer::RabbitConsumer;
+use serde::Deserialize;
+use tokio::time::{timeout, Duration};
+
+#[derive(Deserialize, Debug)]
+struct PaymentEvent {
+    payment_id: u32,
+    order_id: u32,
+    amount: f64,
+    status: String,
+}
+
+async fn process_payment(payment: &PaymentEvent) -> anyhow::Result<()> {
+    // Simulate payment processing
+    println!("Processing payment {} for order {}", payment.payment_id, payment.order_id);
+    
+    // Simulate some processing logic that might fail
+    if payment.amount < 0.0 {
+        return Err(anyhow::anyhow!("Invalid payment amount"));
+    }
+    
+    // Process payment...
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let uri = "amqp://guest:guest@localhost:5672";
+    let queue_name = "payment_events";
+
+    // Connect to RabbitMQ and create consumer
+    let consumer = RabbitConsumer::connect(uri, queue_name).await?;
+
+    // Start consuming messages with manual acknowledgment
+    let mut message_receiver = consumer
+        .load_ackable_messages::<PaymentEvent, _>(10, Some("payment-processor"))
+        .await?;
+
+    println!("Waiting for payment events...");
+
+    // Process messages with manual acknowledgment
+    while let Ok(Some(ackable_message)) = timeout(Duration::from_secs(30), message_receiver.recv()).await {
+        let payment = ackable_message.message();
+        println!("Received payment: {:?}", payment);
+        
+        match process_payment(&payment).await {
+            Ok(()) => {
+                // Success: acknowledge the message
+                if let Err(e) = ackable_message.ack().await {
+                    eprintln!("Failed to acknowledge message: {}", e);
+                }
+                println!("Payment processed and acknowledged");
+            }
+            Err(e) => {
+                eprintln!("Failed to process payment: {}", e);
+                // Reject message and requeue for retry
+                if let Err(e) = ackable_message.nack().await {
+                    eprintln!("Failed to nack message: {}", e);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+```
+
+#### Complete Publisher-Consumer Example
+
+```rust
+use rabbitmq_streamer::{RabbitPublisher, RabbitConsumer};
+use serde::{Serialize, Deserialize};
+use tokio::time::{sleep, timeout, Duration};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct TaskMessage {
+    task_id: u32,
+    task_type: String,
+    payload: String,
+    created_at: u64,
+}
+
+impl TaskMessage {
+    fn new(task_id: u32, task_type: &str, payload: &str) -> Self {
+        Self {
+            task_id,
+            task_type: task_type.to_string(),
+            payload: payload.to_string(),
+            created_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        }
     }
 }
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let uri = "amqp://guest:guest@localhost:5672";
+    let exchange_name = "tasks";
+    let queue_name = "task_queue";
+
+    // Create publisher
+    let publisher = RabbitPublisher::connect(uri, exchange_name, "task_service").await?;
+
+    // Create consumer
+    let consumer = RabbitConsumer::connect(uri, queue_name).await?;
+    let mut message_receiver = consumer
+        .load_ackable_messages::<TaskMessage, _>(20, Some("task-worker"))
+        .await?;
+
+    // Start consumer task
+    let consumer_handle = tokio::spawn(async move {
+        println!("Task worker started...");
+        
+        while let Ok(Some(ackable_message)) = timeout(Duration::from_secs(60), message_receiver.recv()).await {
+            let task = ackable_message.message();
+            println!("Processing task {}: {}", task.task_id, task.task_type);
+            
+            // Simulate task processing
+            sleep(Duration::from_millis(500)).await;
+            
+            // Acknowledge successful processing
+            if let Err(e) = ackable_message.ack().await {
+                eprintln!("Failed to acknowledge task {}: {}", task.task_id, e);
+            } else {
+                println!("Task {} completed successfully", task.task_id);
+            }
+        }
+    });
+
+    // Give consumer time to start
+    sleep(Duration::from_secs(1)).await;
+
+    // Publish some tasks
+    let tasks = vec![
+        TaskMessage::new(1, "email", "Send welcome email"),
+        TaskMessage::new(2, "report", "Generate daily report"),
+        TaskMessage::new(3, "cleanup", "Clean up temp files"),
+    ];
+
+    for task in tasks {
+        let routing_key = format!("tasks.{}", task.task_type);
+        publisher.publish(&task, routing_key).await?;
+        println!("Published task: {}", task.task_id);
+        
+        // Small delay between publications
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    // Wait for consumer to process messages
+    tokio::select! {
+        _ = consumer_handle => {
+            println!("Consumer finished");
+        }
+        _ = sleep(Duration::from_secs(10)) => {
+            println!("Example completed");
+        }
+    }
+
+    Ok(())
+}
+```
+
+#### Add to Cargo.toml
+
+```toml
+[dependencies]
+rabbitmq_streamer = "0.2.0"
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+anyhow = "1.0"
+```
+
+

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,107 @@
+# Testing
+
+This project includes comprehensive tests using testcontainers to ensure that both `RabbitPublisher` and `RabbitConsumer` work correctly with a real RabbitMQ instance.
+
+## Test Structure
+
+### Publisher Tests (`tests/publisher_tests.rs`)
+- **`test_publisher_connect`**: Verifies that the publisher can connect to RabbitMQ
+- **`test_publisher_publish_message`**: Tests publishing a single message
+- **`test_publisher_publish_multiple_messages`**: Tests publishing multiple messages
+- **`test_publisher_with_different_routing_keys`**: Tests publishing with different routing keys
+
+### Consumer Tests (`tests/consumer_tests.rs`)
+- **`test_consumer_connect`**: Verifies that the consumer can connect to RabbitMQ
+- **`test_consumer_load_messages`**: Tests consuming messages with automatic acknowledgment
+- **`test_consumer_load_ackable_messages`**: Tests consuming messages with manual acknowledgment
+- **`test_consumer_with_custom_tag`**: Tests using custom tags for consumers
+
+### Integration Tests (`tests/integration_tests.rs`)
+- **`test_publisher_consumer_integration`**: Tests complete integration between publisher and consumer
+- **`test_publisher_consumer_ackable_integration`**: Tests integration with messages requiring manual acknowledgment
+- **`test_multiple_routing_keys_integration`**: Tests scenarios with multiple routing keys
+
+## Running the Tests
+
+### Prerequisites
+- Docker must be installed and running (testcontainers uses Docker to create RabbitMQ instances)
+- Rust and Cargo installed
+
+### Commands
+
+```bash
+# Run all tests
+cargo test
+
+# Run only publisher tests
+cargo test --test publisher_tests
+
+# Run only consumer tests
+cargo test --test consumer_tests
+
+# Run only integration tests
+cargo test --test integration_tests
+
+# Run tests with detailed output
+cargo test -- --nocapture
+```
+
+## Technologies Used
+
+- **testcontainers**: To create isolated RabbitMQ instances in Docker containers
+- **testcontainers-modules**: Specific module for RabbitMQ
+- **tokio-test**: Utilities for asynchronous tests
+- **serde**: For serialization/deserialization of test messages
+
+## Test Structures
+
+### TestMessage (publisher_tests.rs and consumer_tests.rs)
+```rust
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+struct TestMessage {
+    id: u32,
+    content: String,
+    timestamp: u64,
+}
+```
+
+### OrderEvent (integration_tests.rs)
+```rust
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+struct OrderEvent {
+    order_id: u32,
+    customer_id: u32,
+    action: String,
+    amount: f64,
+    timestamp: u64,
+}
+```
+
+## Test Configuration
+
+The tests automatically create:
+- Temporary RabbitMQ instances using Docker
+- Durable exchanges with appropriate configuration
+- Queues bound to exchanges with appropriate routing keys
+- Test connections with `test:test` credentials
+
+Each test is isolated and uses unique resources to avoid interference between tests.
+
+## Troubleshooting
+
+### Docker not found
+Make sure Docker is installed and the daemon is running:
+```bash
+docker --version
+sudo systemctl start docker
+```
+
+### Test timeouts
+The tests include appropriate timeouts, but if you're on a slow machine, you may need to increase the timeout values in the test files.
+
+### Docker permission issues
+If you get Docker permission errors:
+```bash
+sudo usermod -aG docker $USER
+# Log out and log back in
+```

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,0 @@
-pub fn make_routing_key(app_group_namespace: &str, queue_name: &str) -> String {
-    format!("{}.{}", app_group_namespace, queue_name)
-}

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -6,34 +6,11 @@ pub trait AckableMessageCollectionExtension<T> {
     fn reject(&self) -> impl std::future::Future<Output = anyhow::Result<()>>;
 }
 
-impl<T> AckableMessageCollectionExtension<T>  for Vec<AckableMessage<T>> {
-    async fn ack(&self) -> anyhow::Result<()> {
-        for ackable_message in self.into_iter() {
-            ackable_message.ack().await?;
-        }
 
-        Ok(())
-    }
-
-    async fn nack(&self) -> anyhow::Result<()> {
-        for ackable_message in self.into_iter() {
-            ackable_message.nack().await?;
-        }
-
-        Ok(())
-    }
-
-    async fn reject(&self) -> anyhow::Result<()> {
-        for ackable_message in self.into_iter() {
-            ackable_message.reject().await?;
-        }
-
-        Ok(())
-    }
-}
-
-
-impl<T> AckableMessageCollectionExtension<T>  for Option<AckableMessage<T>> {
+impl<T> AckableMessageCollectionExtension<T> for T where
+    T: IntoIterator<Item = AckableMessage<T>>,
+    T: Copy
+{
     async fn ack(&self) -> anyhow::Result<()> {
         for ackable_message in self.into_iter() {
             ackable_message.ack().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@ pub mod extensions;
 pub mod rabbit_message;
 pub mod consumer;
 pub mod publisher;
-pub mod common;
 
 pub use consumer::RabbitConsumer;
 pub use publisher::RabbitPublisher;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,2 +1,0 @@
-// models.rs
-// Aqui viria o conteúdo do módulo models.

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -1,19 +1,15 @@
 use lapin::{options::{BasicPublishOptions, ExchangeDeclareOptions}, types::FieldTable, BasicProperties, Channel, Connection, ConnectionProperties, ExchangeKind};
 use serde::Serialize;
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 use tracing::instrument;
-
-use crate::common::make_routing_key;
 
 /// A struct representing a RabbitMQ publisher. It holds the necessary information to publish messages to an exchange.
 /// **Parameters**
 /// * `channel`: A reference-counted handle to a channel, which is used to send messages.
 /// * `exchange_name`: The name of the exchange where messages will be published.
-/// * `app_group_namespace`: An identifier for the application used to create routing keys. This helps in segregating messages based on different applications or groups.
 pub struct RabbitPublisher {
     channel: Arc<Channel>,
     exchange_name: String,
-    app_group_namespace: String,
 }
 
 impl RabbitPublisher {
@@ -22,7 +18,6 @@ impl RabbitPublisher {
     /// **Parameters**
     /// * `uri`: The RabbitMQ broker URI.
     /// * `exchange`: The name of the exchange to bind.
-    /// * `app_group_namespace`: An identifier for the application used to create routig keys.
     /// **Returns**
     /// * `RabbitPublisher` - An instance of the publisher connected to the specified RabbitMQ 
     #[instrument]
@@ -36,7 +31,6 @@ impl RabbitPublisher {
         let publisher = Self {
             channel: Arc::new(channel),
             exchange_name: exchange.to_owned(),
-            app_group_namespace: app_group_namespace.to_owned(),
         };
 
         Ok(publisher)
@@ -44,25 +38,28 @@ impl RabbitPublisher {
 
     /// Publishes a message to the specified destination queue.
     /// **Parameters**
-    /// * `destination_queue`: The name of the destination queue.
     /// * `message`: The message to be published.
     /// * `payload`: The message payload.
+    /// * `routing_key`: The routing key for the message.
     /// **Returns**
     /// * `anyhow::Result<()>` - Returns an empty result if the message was successfully published.
     #[instrument(skip(self, message))]
-    pub async fn publish<T: Serialize>(
+    pub async fn publish<T, K>(
         &self,
-        destination_queue: &str,
         message: &T,
-    ) -> anyhow::Result<()> {
-        let routing_key = make_routing_key(&self.app_group_namespace, destination_queue);
+        routing_key: K,
+    ) -> anyhow::Result<()>
+where
+    T: Serialize,
+    K: Into<String> + Debug    
+{
         let payload = serde_json::to_string(&message)?;
         let publish_options = BasicPublishOptions{mandatory: true, immediate: false };
         
         let properties = BasicProperties::default();
 
         self.channel
-            .basic_publish(&self.exchange_name, &routing_key, publish_options, payload.as_bytes(), properties)
+            .basic_publish(&self.exchange_name, &routing_key.into(), publish_options, payload.as_bytes(), properties)
             .await?;
         Ok(())
     }
@@ -84,75 +81,3 @@ async fn bind_exchange(channel: &mut Channel, exchange_name: &str) -> anyhow::Re
     Ok(channel.to_owned())
 }
 
-#[cfg(test)]
-mod tests {
-    use lapin::options::{ExchangeDeleteOptions, QueueBindOptions, QueueDeclareOptions, QueueDeleteOptions};
-
-    use super::*;
-
-    use crate::common::make_routing_key;
-
-    const AMQP_URL: &str = "amqp://admin:password@pipe:5672";
-    const EXCHANGE_NAME: &str = "test";
-    const QUEUE_NAME: &str = "incomming_addresses";
-    const APP_GROUP_NAMESPACE: &str = "test_grup";
-    
-
-    async fn setup_queue(exchange_name: &str) -> anyhow::Result<Channel> {
-        let connection_properties = ConnectionProperties::default();
-        let connection = Connection::connect(AMQP_URL, connection_properties).await?;
-        let channel = connection.create_channel().await?;
-        
-        let exchange_declare_options = ExchangeDeclareOptions {
-            durable: true,
-            auto_delete: false,
-            internal: false,
-            nowait: false,
-            passive: false,
-            ..ExchangeDeclareOptions::default()
-        };
-
-        let queue_declare_options = QueueDeclareOptions{
-            passive: true,
-            durable: true,
-            exclusive: false,
-            auto_delete: false,
-            nowait: false,
-        };
-        
-        let routing_key = make_routing_key(APP_GROUP_NAMESPACE, QUEUE_NAME);
-        let queue_bind_options = QueueBindOptions { nowait: false, };
-        channel.queue_declare(EXCHANGE_NAME, queue_declare_options, FieldTable::default()).await?;
-        channel.queue_bind(QUEUE_NAME, EXCHANGE_NAME, &routing_key, queue_bind_options, FieldTable::default()).await?;
-
-        Ok(channel)
-    }
-
-    async fn setup_publisher() -> RabbitPublisher {
-        let publisher_client = RabbitPublisher::connect(AMQP_URL, EXCHANGE_NAME, APP_GROUP_NAMESPACE).await.unwrap();
-        publisher_client
-    }
-
-    async fn tear_down(channel: Channel) -> anyhow::Result<()> {
-
-        channel.exchange_delete(QUEUE_NAME, ExchangeDeleteOptions::default()).await?;
-        channel.queue_delete(QUEUE_NAME, QueueDeleteOptions::default()).await?;
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_one_message_can_be_published() -> anyhow::Result<()> {
-        let channel = setup_queue(EXCHANGE_NAME).await?;
-        let client = setup_publisher().await;
-
-        let addresses = vec![
-            "Rua Barão de Mesquita".to_owned(),
-            "Rua Zé das couves".to_owned(),
-            "Rua Perto da Padaria".to_owned(),
-        ];
-
-        tear_down(channel).await?;
-        Ok(())        
-    }
-}

--- a/tests/consumer_tests.rs
+++ b/tests/consumer_tests.rs
@@ -1,0 +1,243 @@
+use rabbitmq_streamer::RabbitConsumer;
+use serde::{Deserialize, Serialize};
+use testcontainers::{runners::AsyncRunner, ContainerAsync, ImageExt};
+use testcontainers_modules::rabbitmq::RabbitMq;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+struct TestMessage {
+    id: u32,
+    content: String,
+    timestamp: u64,
+}
+
+impl TestMessage {
+    fn new(id: u32, content: &str) -> Self {
+        Self {
+            id,
+            content: content.to_string(),
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        }
+    }
+}
+
+async fn setup_rabbitmq_container() -> (ContainerAsync<RabbitMq>, String) {
+    let rabbitmq_image = RabbitMq::default()
+        .with_env_var("RABBITMQ_DEFAULT_USER", "test")
+        .with_env_var("RABBITMQ_DEFAULT_PASS", "test");
+    
+    let container = rabbitmq_image.start().await.expect("Failed to start RabbitMQ container");
+    
+    let host = container.get_host().await.expect("Failed to get container host");
+    let port = container.get_host_port_ipv4(5672).await.expect("Failed to get container port");
+    let connection_string = format!("amqp://test:test@{}:{}", host, port);
+    
+    // Wait a bit for RabbitMQ to be fully ready
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    
+    (container, connection_string)
+}
+
+async fn setup_queue_with_messages(connection_string: &str, queue_name: &str) -> anyhow::Result<()> {
+    use lapin::{
+        options::{ExchangeDeclareOptions, QueueBindOptions, QueueDeclareOptions, BasicPublishOptions},
+        types::FieldTable,
+        Connection, ConnectionProperties, ExchangeKind, BasicProperties,
+    };
+
+    let connection = Connection::connect(connection_string, ConnectionProperties::default()).await?;
+    let channel = connection.create_channel().await?;
+    
+    // Declare exchange with durable=true to match publisher configuration
+    channel.exchange_declare(
+        "test_exchange",
+        ExchangeKind::Direct,
+        ExchangeDeclareOptions {
+            durable: true,
+            auto_delete: false,
+            internal: false,
+            nowait: false,
+            passive: false,
+            ..ExchangeDeclareOptions::default()
+        },
+        FieldTable::default(),
+    ).await?;
+    
+    // Declare queue
+    channel.queue_declare(
+        queue_name,
+        QueueDeclareOptions::default(),
+        FieldTable::default(),
+    ).await?;
+    
+    // Bind queue to exchange
+    channel.queue_bind(
+        queue_name,
+        "test_exchange", 
+        "test.routing.key",
+        QueueBindOptions::default(),
+        FieldTable::default(),
+    ).await?;
+    
+    // Publish some test messages
+    for i in 1..=3 {
+        let message = TestMessage::new(i, &format!("Test message {}", i));
+        let payload = serde_json::to_string(&message)?;
+        channel.basic_publish(
+            "test_exchange",
+            "test.routing.key",
+            BasicPublishOptions::default(),
+            payload.as_bytes(),
+            BasicProperties::default(),
+        ).await?;
+    }
+    
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_consumer_connect() {
+    let (_container, connection_string) = setup_rabbitmq_container().await;
+    
+    let _consumer = RabbitConsumer::connect(&connection_string, "test_queue")
+        .await
+        .expect("Failed to connect consumer");
+    
+    // If we get here without panicking, the connection was successful
+    assert!(true);
+}
+
+#[tokio::test]
+async fn test_consumer_load_messages() {
+    let (_container, connection_string) = setup_rabbitmq_container().await;
+    
+    // Setup queue with messages
+    setup_queue_with_messages(&connection_string, "test_queue_load").await
+        .expect("Failed to setup queue with messages");
+    
+    let consumer = RabbitConsumer::connect(&connection_string, "test_queue_load")
+        .await
+        .expect("Failed to connect consumer");
+    
+    let mut message_receiver = consumer.load_messages::<TestMessage, _>(10, Some("test-consumer"))
+        .await
+        .expect("Failed to load messages");
+    
+    // Give some time for messages to be consumed
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    
+    let mut received_messages = Vec::new();
+    let mut count = 0;
+    
+    // Try to receive messages with timeout
+    while count < 3 {
+        tokio::select! {
+            message = message_receiver.recv() => {
+                if let Some(msg) = message {
+                    received_messages.push(msg);
+                    count += 1;
+                } else {
+                    break;
+                }
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {
+                break;
+            }
+        }
+    }
+    
+    assert!(received_messages.len() > 0, "Should have received at least one message");
+    assert!(received_messages.len() <= 3, "Should not receive more than 3 messages");
+    
+    // Verify message structure
+    for msg in &received_messages {
+        assert!(msg.id > 0);
+        assert!(msg.content.contains("Test message"));
+    }
+}
+
+#[tokio::test]
+async fn test_consumer_load_ackable_messages() {
+    let (_container, connection_string) = setup_rabbitmq_container().await;
+    
+    // Setup queue with messages
+    setup_queue_with_messages(&connection_string, "test_queue_ackable").await
+        .expect("Failed to setup queue with messages");
+    
+    let consumer = RabbitConsumer::connect(&connection_string, "test_queue_ackable")
+        .await
+        .expect("Failed to connect consumer");
+    
+    let mut message_receiver = consumer.load_ackable_messages::<TestMessage, _>(10, Some("test-ackable-consumer"))
+        .await
+        .expect("Failed to load ackable messages");
+    
+    // Give some time for messages to be consumed
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    
+    let mut received_messages = Vec::new();
+    let mut count = 0;
+    
+    // Try to receive messages with timeout
+    while count < 3 {
+        tokio::select! {
+            message = message_receiver.recv() => {
+                if let Some(ackable_msg) = message {
+                    let msg = ackable_msg.message();
+                    received_messages.push(msg);
+                    
+                    // Acknowledge the message
+                    ackable_msg.ack().await.expect("Failed to ack message");
+                    count += 1;
+                } else {
+                    break;
+                }
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {
+                break;
+            }
+        }
+    }
+    
+    assert!(received_messages.len() > 0, "Should have received at least one ackable message");
+    assert!(received_messages.len() <= 3, "Should not receive more than 3 ackable messages");
+    
+    // Verify message structure
+    for msg in &received_messages {
+        assert!(msg.id > 0);
+        assert!(msg.content.contains("Test message"));
+    }
+}
+
+#[tokio::test]
+async fn test_consumer_with_custom_tag() {
+    let (_container, connection_string) = setup_rabbitmq_container().await;
+    
+    // Setup queue with messages
+    setup_queue_with_messages(&connection_string, "test_queue_custom_tag").await
+        .expect("Failed to setup queue with messages");
+    
+    let consumer = RabbitConsumer::connect(&connection_string, "test_queue_custom_tag")
+        .await
+        .expect("Failed to connect consumer");
+    
+    let custom_tag = "my-custom-consumer-tag";
+    let mut message_receiver = consumer.load_messages::<TestMessage, _>(5, Some(custom_tag))
+        .await
+        .expect("Failed to load messages with custom tag");
+    
+    // Give some time for messages to be consumed
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    
+    // Just verify we can receive at least one message
+    tokio::select! {
+        message = message_receiver.recv() => {
+            assert!(message.is_some(), "Should have received a message with custom tag");
+        }
+        _ = tokio::time::sleep(std::time::Duration::from_secs(3)) => {
+            panic!("Timeout waiting for message with custom tag");
+        }
+    }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,330 @@
+use rabbitmq_streamer::{RabbitConsumer, RabbitPublisher};
+use serde::{Deserialize, Serialize};
+use testcontainers::{runners::AsyncRunner, ContainerAsync, ImageExt};
+use testcontainers_modules::rabbitmq::RabbitMq;
+use tokio::time::{timeout, Duration};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+struct OrderEvent {
+    order_id: u32,
+    customer_id: u32,
+    action: String,
+    amount: f64,
+    timestamp: u64,
+}
+
+impl OrderEvent {
+    fn new(order_id: u32, customer_id: u32, action: &str, amount: f64) -> Self {
+        Self {
+            order_id,
+            customer_id,
+            action: action.to_string(),
+            amount,
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        }
+    }
+}
+
+async fn setup_rabbitmq_container() -> (ContainerAsync<RabbitMq>, String) {
+    let rabbitmq_image = RabbitMq::default()
+        .with_env_var("RABBITMQ_DEFAULT_USER", "test")
+        .with_env_var("RABBITMQ_DEFAULT_PASS", "test");
+    
+    let container = rabbitmq_image.start().await.expect("Failed to start RabbitMQ container");
+    
+    let host = container.get_host().await.expect("Failed to get container host");
+    let port = container.get_host_port_ipv4(5672).await.expect("Failed to get container port");
+    let connection_string = format!("amqp://test:test@{}:{}", host, port);
+    
+    // Wait a bit for RabbitMQ to be fully ready
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    
+    (container, connection_string)
+}
+
+async fn setup_queue_binding(connection_string: &str, queue_name: &str, exchange_name: &str, routing_key: &str) -> anyhow::Result<()> {
+    use lapin::{
+        options::{ExchangeDeclareOptions, QueueBindOptions, QueueDeclareOptions},
+        types::FieldTable,
+        Connection, ConnectionProperties, ExchangeKind,
+    };
+
+    let connection = Connection::connect(connection_string, ConnectionProperties::default()).await?;
+    let channel = connection.create_channel().await?;
+    
+    // Declare exchange with durable=true to match publisher configuration
+    channel.exchange_declare(
+        exchange_name,
+        ExchangeKind::Direct,
+        ExchangeDeclareOptions {
+            durable: true,
+            auto_delete: false,
+            internal: false,
+            nowait: false,
+            passive: false,
+            ..ExchangeDeclareOptions::default()
+        },
+        FieldTable::default(),
+    ).await?;
+    
+    // Declare queue
+    channel.queue_declare(
+        queue_name,
+        QueueDeclareOptions::default(),
+        FieldTable::default(),
+    ).await?;
+    
+    // Bind queue to exchange
+    channel.queue_bind(
+        queue_name,
+        exchange_name, 
+        routing_key,
+        QueueBindOptions::default(),
+        FieldTable::default(),
+    ).await?;
+    
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_publisher_consumer_integration() {
+    let (_container, connection_string) = setup_rabbitmq_container().await;
+    
+    let exchange_name = "orders_exchange";
+    let queue_name = "orders_queue";
+    let routing_key = "orders.created";
+    
+    // Setup queue binding
+    setup_queue_binding(&connection_string, queue_name, exchange_name, routing_key).await
+        .expect("Failed to setup queue binding");
+    
+    // Create publisher
+    let publisher = RabbitPublisher::connect(&connection_string, exchange_name, "test_app")
+        .await
+        .expect("Failed to connect publisher");
+    
+    // Create consumer
+    let consumer = RabbitConsumer::connect(&connection_string, queue_name)
+        .await
+        .expect("Failed to connect consumer");
+    
+    // Start consuming messages
+    let mut message_receiver = consumer.load_messages::<OrderEvent, _>(10, Some("integration-test-consumer"))
+        .await
+        .expect("Failed to start consuming messages");
+    
+    // Give consumer a moment to start
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    
+    // Publish test messages
+    let test_orders = vec![
+        OrderEvent::new(1, 100, "created", 99.99),
+        OrderEvent::new(2, 101, "created", 149.50),
+        OrderEvent::new(3, 102, "created", 299.00),
+    ];
+    
+    for order in &test_orders {
+        publisher.publish(order, routing_key).await
+            .expect("Failed to publish order event");
+    }
+    
+    // Collect received messages
+    let mut received_orders = Vec::new();
+    let receive_timeout = Duration::from_secs(5);
+    
+    for _ in 0..test_orders.len() {
+        match timeout(receive_timeout, message_receiver.recv()).await {
+            Ok(Some(order)) => {
+                received_orders.push(order);
+            }
+            Ok(None) => {
+                break; // Channel closed
+            }
+            Err(_) => {
+                break; // Timeout
+            }
+        }
+    }
+    
+    // Verify we received the messages
+    assert_eq!(received_orders.len(), test_orders.len(), 
+        "Should have received all {} published messages, got {}", 
+        test_orders.len(), received_orders.len());
+    
+    // Verify message content (order may vary)
+    for received_order in &received_orders {
+        let matching_order = test_orders.iter().find(|&test_order| {
+            test_order.order_id == received_order.order_id &&
+            test_order.customer_id == received_order.customer_id &&
+            test_order.action == received_order.action &&
+            (test_order.amount - received_order.amount).abs() < 0.01
+        });
+        
+        assert!(matching_order.is_some(), 
+            "Received order {:?} should match one of the published orders", 
+            received_order);
+    }
+}
+
+#[tokio::test]
+async fn test_publisher_consumer_ackable_integration() {
+    let (_container, connection_string) = setup_rabbitmq_container().await;
+    
+    let exchange_name = "orders_ackable_exchange";
+    let queue_name = "orders_ackable_queue";
+    let routing_key = "orders.updated";
+    
+    // Setup queue binding
+    setup_queue_binding(&connection_string, queue_name, exchange_name, routing_key).await
+        .expect("Failed to setup queue binding");
+    
+    // Create publisher
+    let publisher = RabbitPublisher::connect(&connection_string, exchange_name, "test_app")
+        .await
+        .expect("Failed to connect publisher");
+    
+    // Create consumer
+    let consumer = RabbitConsumer::connect(&connection_string, queue_name)
+        .await
+        .expect("Failed to connect consumer");
+    
+    // Start consuming ackable messages
+    let mut message_receiver = consumer.load_ackable_messages::<OrderEvent, _>(10, Some("ackable-integration-test-consumer"))
+        .await
+        .expect("Failed to start consuming ackable messages");
+    
+    // Give consumer a moment to start
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    
+    // Publish test messages
+    let test_orders = vec![
+        OrderEvent::new(10, 200, "updated", 109.99),
+        OrderEvent::new(11, 201, "updated", 159.50),
+    ];
+    
+    for order in &test_orders {
+        publisher.publish(order, routing_key).await
+            .expect("Failed to publish order event");
+    }
+    
+    // Collect and acknowledge received messages
+    let mut received_orders = Vec::new();
+    let receive_timeout = Duration::from_secs(5);
+    
+    for _ in 0..test_orders.len() {
+        match timeout(receive_timeout, message_receiver.recv()).await {
+            Ok(Some(ackable_message)) => {
+                let order = ackable_message.message();
+                received_orders.push(order);
+                
+                // Acknowledge the message
+                ackable_message.ack().await.expect("Failed to acknowledge message");
+            }
+            Ok(None) => {
+                break; // Channel closed
+            }
+            Err(_) => {
+                break; // Timeout
+            }
+        }
+    }
+    
+    // Verify we received and acknowledged the messages
+    assert_eq!(received_orders.len(), test_orders.len(), 
+        "Should have received all {} published ackable messages, got {}", 
+        test_orders.len(), received_orders.len());
+    
+    // Verify message content
+    for received_order in &received_orders {
+        let matching_order = test_orders.iter().find(|&test_order| {
+            test_order.order_id == received_order.order_id &&
+            test_order.action == received_order.action
+        });
+        
+        assert!(matching_order.is_some(), 
+            "Received ackable order {:?} should match one of the published orders", 
+            received_order);
+    }
+}
+
+#[tokio::test]
+async fn test_multiple_routing_keys_integration() {
+    let (_container, connection_string) = setup_rabbitmq_container().await;
+    
+    let exchange_name = "multi_routing_exchange";
+    let queue_name = "multi_routing_queue";
+    
+    // Setup multiple routing key bindings
+    let routing_keys = vec!["orders.created", "orders.updated", "orders.deleted"];
+    
+    for routing_key in &routing_keys {
+        setup_queue_binding(&connection_string, queue_name, exchange_name, routing_key).await
+            .expect(&format!("Failed to setup queue binding for {}", routing_key));
+    }
+    
+    // Create publisher
+    let publisher = RabbitPublisher::connect(&connection_string, exchange_name, "test_app")
+        .await
+        .expect("Failed to connect publisher");
+    
+    // Create consumer
+    let consumer = RabbitConsumer::connect(&connection_string, queue_name)
+        .await
+        .expect("Failed to connect consumer");
+    
+    // Start consuming messages
+    let mut message_receiver = consumer.load_messages::<OrderEvent, _>(20, Some("multi-routing-consumer"))
+        .await
+        .expect("Failed to start consuming messages");
+    
+    // Give consumer a moment to start
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    
+    // Publish messages with different routing keys
+    let test_data = vec![
+        (OrderEvent::new(20, 300, "created", 199.99), "orders.created"),
+        (OrderEvent::new(21, 301, "updated", 219.99), "orders.updated"),
+        (OrderEvent::new(22, 302, "deleted", 0.0), "orders.deleted"),
+        (OrderEvent::new(23, 303, "created", 99.99), "orders.created"),
+    ];
+    
+    for (order, routing_key) in &test_data {
+        publisher.publish(order, *routing_key).await
+            .expect(&format!("Failed to publish order with routing key {}", routing_key));
+    }
+    
+    // Collect received messages
+    let mut received_orders = Vec::new();
+    let receive_timeout = Duration::from_secs(5);
+    
+    for _ in 0..test_data.len() {
+        match timeout(receive_timeout, message_receiver.recv()).await {
+            Ok(Some(order)) => {
+                received_orders.push(order);
+            }
+            Ok(None) => {
+                break; // Channel closed
+            }
+            Err(_) => {
+                break; // Timeout
+            }
+        }
+    }
+    
+    // Verify we received all messages from different routing keys
+    assert_eq!(received_orders.len(), test_data.len(), 
+        "Should have received all {} messages from different routing keys, got {}", 
+        test_data.len(), received_orders.len());
+    
+    // Count messages by action type
+    let created_count = received_orders.iter().filter(|o| o.action == "created").count();
+    let updated_count = received_orders.iter().filter(|o| o.action == "updated").count();
+    let deleted_count = received_orders.iter().filter(|o| o.action == "deleted").count();
+    
+    assert_eq!(created_count, 2, "Should have received 2 'created' messages");
+    assert_eq!(updated_count, 1, "Should have received 1 'updated' message");
+    assert_eq!(deleted_count, 1, "Should have received 1 'deleted' message");
+}

--- a/tests/publisher_tests.rs
+++ b/tests/publisher_tests.rs
@@ -1,0 +1,100 @@
+use rabbitmq_streamer::RabbitPublisher;
+use serde::{Deserialize, Serialize};
+use testcontainers::{runners::AsyncRunner, ContainerAsync, ImageExt};
+use testcontainers_modules::rabbitmq::RabbitMq;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+struct TestMessage {
+    id: u32,
+    content: String,
+    timestamp: u64,
+}
+
+impl TestMessage {
+    fn new(id: u32, content: &str) -> Self {
+        Self {
+            id,
+            content: content.to_string(),
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        }
+    }
+}
+
+async fn setup_rabbitmq_container() -> (ContainerAsync<RabbitMq>, String) {
+    let rabbitmq_image = RabbitMq::default()
+        .with_env_var("RABBITMQ_DEFAULT_USER", "test")
+        .with_env_var("RABBITMQ_DEFAULT_PASS", "test");
+    
+    let container = rabbitmq_image.start().await.expect("Failed to start RabbitMQ container");
+    
+    let host = container.get_host().await.expect("Failed to get container host");
+    let port = container.get_host_port_ipv4(5672).await.expect("Failed to get container port");
+    let connection_string = format!("amqp://test:test@{}:{}", host, port);
+    
+    // Wait a bit for RabbitMQ to be fully ready
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    
+    (container, connection_string)
+}
+
+#[tokio::test]
+async fn test_publisher_connect() {
+    let (_container, connection_string) = setup_rabbitmq_container().await;
+    
+    let _publisher = RabbitPublisher::connect(&connection_string, "test_exchange", "test_app")
+        .await
+        .expect("Failed to connect publisher");
+    
+    // If we get here without panicking, the connection was successful
+    assert!(true);
+}
+
+#[tokio::test]
+async fn test_publisher_publish_message() {
+    let (_container, connection_string) = setup_rabbitmq_container().await;
+    
+    let publisher = RabbitPublisher::connect(&connection_string, "test_exchange", "test_app")
+        .await
+        .expect("Failed to connect publisher");
+    
+    let test_message = TestMessage::new(1, "Hello RabbitMQ!");
+    
+    let result = publisher.publish(&test_message, "test.routing.key").await;
+    
+    assert!(result.is_ok(), "Failed to publish message: {:?}", result);
+}
+
+#[tokio::test]
+async fn test_publisher_publish_multiple_messages() {
+    let (_container, connection_string) = setup_rabbitmq_container().await;
+    
+    let publisher = RabbitPublisher::connect(&connection_string, "test_exchange", "test_app")
+        .await
+        .expect("Failed to connect publisher");
+    
+    for i in 1..=5 {
+        let test_message = TestMessage::new(i, &format!("Message {}", i));
+        let result = publisher.publish(&test_message, format!("test.routing.key.{}", i)).await;
+        assert!(result.is_ok(), "Failed to publish message {}: {:?}", i, result);
+    }
+}
+
+#[tokio::test]
+async fn test_publisher_with_different_routing_keys() {
+    let (_container, connection_string) = setup_rabbitmq_container().await;
+    
+    let publisher = RabbitPublisher::connect(&connection_string, "test_exchange", "test_app")
+        .await
+        .expect("Failed to connect publisher");
+    
+    let routing_keys = vec!["orders.created", "orders.updated", "orders.deleted"];
+    
+    for (i, routing_key) in routing_keys.iter().enumerate() {
+        let test_message = TestMessage::new(i as u32 + 1, &format!("Order event: {}", routing_key));
+        let result = publisher.publish(&test_message, *routing_key).await;
+        assert!(result.is_ok(), "Failed to publish message with routing key {}: {:?}", routing_key, result);
+    }
+}


### PR DESCRIPTION
The 0.x version was very opinated on how the queue binding should work, now, instead of that, this PR address changes to make it free for the user to publishe in a given exchange, with any routing key, and consume from a given queue, without binding it to a exhange.